### PR TITLE
Added install-docs.md containing instructions on how to run the documentation site locally.

### DIFF
--- a/Install-docs.md
+++ b/Install-docs.md
@@ -69,7 +69,16 @@ You can attach to the running container with:
 ```
 docker attach ct-docs-container
 ```    
-After attaching, you have to stop the development server by pressing CTRL+C.
+After attaching, you have to stop the documentaion development server by pressing CTRL+C.
+
+### Commands to Run
+
+If you run the container in the foreground with Bash, here's a couple of helpful commands:
+
+* start the local documentation development server
+```
+mkdocs serve -a 0.0.0.0:8000
+```
 
 ### Closing the Running Container
 


### PR DESCRIPTION
Solved issue #12  .

Key Points Added:
- install intructructions for:
     1. creating a docker image
     2. creating a container from the docker image.
- Note added , incase the user has the main site running on localhost:8000.
- instructions added on how to attach to a  running container.
- instructions on how to Cleanly close and Kill the container also added.