### PR TITLE
Issue 22: Add DB migrate step 1st time install

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -119,6 +119,7 @@ update these directions soon.
 1. To set up new virtual environment, run `virtualenv venv`
 1. To activate virtual environment, run `source venv/bin/activate`
 1. Run `pip3 install -r requirements.txt` to install all the needed dependencies
+1. (first time use on new installs) Run `python manage.py migrate` to upgrade the database
 1. Then run `python3 manage.py runserver` to start the server
 1. In your browser, visit [http://localhost:8000/](http://localhost:8000/) or [http://127.0.0.1:8000/](http://127.0.0.1:8000/)
 1. Press CTRL+C in the terminal to stop the server
@@ -139,6 +140,7 @@ search online for instructions on using your distribution's package manager.
 1. Set up the Python virtual environment with `python3 -m venv venv`
 1. Activate the virtual environment with `source venv/bin/activate`
 1. Install the dependencies with `pip install -r requirements.txt`
+1. (first time use on new installs) Run `python manage.py migrate` to upgrade the database
 1. Then run the app with `python3 manage.py runserver`
 1. In your browser, visit [http://localhost:8000/](http://localhost:8000/) or [http://127.0.0.1:8000/](http://127.0.0.1:8000/)
 1. Press CTRL+C in the terminal to stop the server

--- a/docs/install.md
+++ b/docs/install.md
@@ -99,6 +99,7 @@ suffix all `python` and `pip` commands with `3`, e.g. `pip3` and `python3`, or f
 1. To set up new virtual environment, run `virtualenv venv`
 1. To activate virtual environment, run `venv\Scripts\activate.bat`
 1. Run `pip install -r requirements.txt` to install all the needed dependencies
+1. (first time use on new installs) Run `python manage.py migrate` to upgrade the database
 1. Then run `python manage.py runserver` to start the server
 1. In your browser, visit [http://localhost:8000/](http://localhost:8000/) or [http://127.0.0.1:8000/](http://127.0.0.1:8000/) 
 1. Press CTRL+C in the terminal to stop the server


### PR DESCRIPTION
Propose adding a step to the manual install instructions as...
(first time use on new installs) Run python manage.py migrate to upgrade the database

This is to resolve #22 