### PR TITLE
Fix links on quick_start

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -2,18 +2,18 @@
 
 ## Installation
 
-After forking the repository you can run this command to have your own instance of CodeThesaurus 
+After forking the repository you can run this command to have your own instance of CodeThesaurus
 
 ```bash
 $ docker-compose up
 ```
-Need more details? Check out the [Docker instruction](https://github.com/componentjs/guide/blob/master/component/getting-started.md) or [Installtion guide](https://github.com/codethesaurus/docs/blob/main/Install-docs.md).
+Need more details? Check out the [Installtion guide](/install/).
 
 
 ### Developer's guide
 The thesaurus files are the core data elements behind Code Thesaurus. They include all the information that is aggregated together to show the user as they go to compare things.
 
-For instructions on editing your CodeThesaurus instance, refer to the [Thesaurus File](https://docs.codethesaur.us/thesaurus/) 
+For instructions on editing your CodeThesaurus instance, refer to the [Thesaurus File](/thesaurus/)
 
 
 ## Code Organization
@@ -23,10 +23,10 @@ For instructions on editing your CodeThesaurus instance, refer to the [Thesaurus
 
 
 ## Architecture
-There are three main part to our architecture 
+There are three main part to our architecture
 
 - Web
 - Programming Language Data
 - Meta Data
 
-You can check out more details about our architecture here [Project Architecture](https://github.com/codethesaurus/docs/blob/main/docs/project_architecture.md)
+You can check out more details about our architecture here [Project Architecture](/project_architecture/)


### PR DESCRIPTION
There were some issues with the links on quick_start:
- One link that linked to an unrelated github project
- some others linked to `.md` files on github but should just link to their generated docs
- yet another link hardcoded `docs.codethesaurs.us` which I replaced with a site relative link for easier local development and/or domain change.
