### PR TITLE
Fixing the generate_template command

### DIFF
--- a/docs/thesaurus/index.md
+++ b/docs/thesaurus/index.md
@@ -38,7 +38,7 @@ You can open that structure file and add or edit any language features you find 
 The ID names for each of the concepts is consistent across all the languages in order to help match up the concepts with each other. The ID has to stay the same, but the other data doesn't have to (and maybe shouldn't).
 
 If the language doesn't have that structure file yet, you can generate a template either by visiting `https://codethesaur.us/reference/?concept=<your_concept>&lang=<language>%3B<language_major_version>`
-and copying it over from there or use `./manage.py generate_templates --language_version=<language_version> <language> <structure>` to generate a file pre filled with the relevant meta info on the top waiting for you to fill the various code segments.
+and copying it over from there or use `./manage.py generate_template --language-version=<language_version> <language> <structure>` to generate a file pre filled with the relevant meta info on the top waiting for you to fill the various code segments.
 
 If you have any questions about it, you are welcome to ask through:
 


### PR DESCRIPTION
The `generate_template` command to `manage.py` has the wrong command name and argument `_` vs `-`

```
$ ./manage.py generate_template --language-version=9 vimscript control_structures
NOTE: The language "vimscript" did not exist yet, make sure to add it in "web/thesauruses/meta_info.json" and adjust "language_name" in the "meta" section or it will not be picked up!

Created template file "web/thesauruses/vimscript/9/control_structures.json" which you can now edit.
```