### PR TITLE
Fix generate_template manage.py command

### DIFF
--- a/docs/thesaurus/add-lang-concept.md
+++ b/docs/thesaurus/add-lang-concept.md
@@ -7,7 +7,7 @@ You can open that structure file and add or edit any language features you find 
 The ID names for each of the concepts is consistent across all the languages in order to help match up the concepts with each other. The ID has to stay the same, but the other data doesn't have to (and maybe shouldn't).
 
 If the language doesn't have that structure file yet, you can generate a template either by visiting `https://codethesaur.us/reference/?concept=<your_concept>&lang=<language>%3B<language_major_version>`
-and copying it over from there or use `./manage.py generate_templates --language_version=<language_version> <language> <structure>` to generate a file pre-filled with the relevant meta info on the top waiting for you to fill the various code segments.
+and copying it over from there or use `./manage.py generate_template --language-version=<language_version> <language> <structure>` to generate a file pre-filled with the relevant meta info on the top waiting for you to fill the various code segments.
 
 If you have any questions about it, you are welcome to ask through:
 


### PR DESCRIPTION
The `generate_template` command in the docs has the wrong command name (plural vs singular) and the wrong argument `--language_version` (incorrect) vs `--language-version` (correct)